### PR TITLE
added swift 6 support, migrated handleOpen and trackConversion to async and added tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+# JetBrains IDEs
+.idea/

--- a/Package.swift
+++ b/Package.swift
@@ -5,16 +5,20 @@ import PackageDescription
 
 let package = Package(
     name: "ShortIOSDK",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12)
+    ],
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
             name: "ShortIOSDK",
             targets: ["ShortIOSDK"]),
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "ShortIOSDK")
+            name: "ShortIOSDK"),
+        .testTarget(
+            name: "ShortIOSDKTests",
+            dependencies: ["ShortIOSDK"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ import ShortIOSDK
 
 let sdk = ShortIOSDK.shared
 
+// The domain comes from initialize(apiKey:domain:) — no need to repeat it here.
 let parameters = ShortIOParameters(
-    domain: "your_domain", // Replace with your Short.io domain
-    originalURL: "https://{your_domain}"// Replace with your Short.io domain
+    originalURL: "https://example.com/your/long/url" // the URL you want shortened
 )
 ```
-**Note**: The `originalURL` are the required parameter. You can also pass optional parameters such as `path`, `title`, `utmParameters`, etc.
+**Note**: `originalURL` is the only required parameter — and it is the **destination** URL you want to shorten, not your Short.io domain. You can also pass optional parameters such as `path`, `title`, `utmSource`, etc.
 
-- `domain` parameter is deprecated. Use the instance's configured API key instead. Call initialize(apiKey:domain:) before using this method.
+- The `domain` parameter is deprecated and will be removed in 2.0.0. A domain is still **required** by the API — supply it once via `initialize(apiKey:domain:)` and every request will use it. Setting `domain` here overrides that for a single call.
 
 ``` swift
 let apiKey = "your_public_apiKey" // Replace with your Short.io Public API Key
@@ -119,7 +119,7 @@ Task {
     }
 }
 ```
-**⚠️ Note**: The `apiKey` parameter is deprecated. Use the instance's configured API key instead. Call initialize(apiKey:domain:) before using this method.
+**⚠️ Note**: The `apiKey` parameter is deprecated. Call `initialize(apiKey:domain:)` first, then use `createShortLink(parameters:)`. This overload will be removed in 2.0.0.
 
 ## 📄 API Parameters
 
@@ -128,7 +128,7 @@ The `ShortIOParameters` struct is used to define the details of the short link y
 
 | Parameter           | Type         | Required  | Description                                                  |
 | ------------------- | -----------  | --------  | ------------------------------------------------------------ |
-| `domain`            | `String`     | ✅ (Deprecated)        | ⚠️ Deprecated. No longer required — inferred from API key. May be removed in future versions.             |
+| `domain`            | `String`     | ⚠️ (Deprecated)        | ⚠️ Deprecated — pass it to `initialize(apiKey:domain:)` instead, which supplies it for every request. Setting it here overrides that. Removed in 2.0.0. |
 | `originalURL`       | `String`     | ✅        | The original URL to be shortened                             |
 | `cloaking`          | `Bool`       | ❌        | If `true`, hides the destination URL from the user           |
 | `password`          | `String`     | ❌        | Password to protect the short link                           |
@@ -200,9 +200,7 @@ let sdk = ShortIOSDK.shared
 Task {
     do {
         let result = try await sdk.trackConversion(
-            domain: "your_domain", // ⚠️ Deprecated (optional):
-            clid: "your_clid", // ⚠️ Deprecated (optional):
-            conversionId: "your_conversionID" (optional)
+            conversionId: "your_conversionID" // optional
         )
         print("result", result)
     } catch {
@@ -211,8 +209,9 @@ Task {
 }
 ```
 
-**⚠️ Note:** All three parameters — `domain`, `clid`, and `conversionId` — are optional.
-- `domain` and `clid` are deprecated and may be removed in future versions.
+**Note:** `conversionId` is optional. The `clid` is captured automatically by `handleOpen(_:)` when the user opens the link, and the domain comes from `initialize(apiKey:domain:)` — so neither needs to be passed.
+
+**⚠️ Deprecated:** the `trackConversion(clid:domain:conversionId:)` overload still works, but is deprecated as of `1.1.0` and **will be removed in `2.0.0`**. Xcode offers a fix-it to migrate to `trackConversion(conversionId:)`.
 
 ## 🌐 Deep Linking Setup (Universal Links for iOS)
 
@@ -256,9 +255,16 @@ ABCDEFGHIJ.com.example.app
 
 This guide explains how to handle Universal Links in iOS applications using the SDK's `handleOpen` function. Below are implementation details for both SwiftUI and Storyboard-based projects.
 
+The SDK resolves the short link and returns the `URLComponents` of its **destination** — not of the short link you passed in:
+
+* `url` → The destination URL the short link points to.
+* `host` → The destination's host.
+* `path` → The destination's path.
+* `queryItems` → The destination's query parameters.
+
 ### SwiftUI Project
 
-For SwiftUI apps, use the `onOpenURL` modifier at the entry point of your app to process incoming URLs and navigate to the appropriate views. Below is an example implementation in SwiftUI.
+For SwiftUI apps, use the `onOpenURL` modifier at the entry point of your app to process incoming URLs and retrieve the original URL. Below is an example implementation in SwiftUI.
 
 ```swift
 import SwiftUI
@@ -266,24 +272,26 @@ import ShortIOSDK
 
 @main
 struct YourApp: App {
-    
+
     let sdk = ShortIOSDK.shared
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .onOpenURL { url in
-                    print("url", url)
-                    sdk.handleOpen(url) { result in
-                        switch result {
-                        case .success(let result):
+                    Task {
+                        do {
+                            let components = try await sdk.handleOpen(url)
                             // Handle successful URL processing
-                            print("result", result, "Host: \(result.host), Path: \(result.path)", "QueryParams: \(result.queryItems)")
-                        case .failure(let error):
+                            print(
+                                "Original URL: \(components.url?.absoluteString ?? "unknown")",
+                                "Host: \(components.host ?? "nil"), Path: \(components.path)",
+                                "QueryParams: \(components.queryItems ?? [])"
+                            )
+                        } catch {
                             // Handle error with proper error type
                             print("Error: \(error.localizedDescription)")
                         }
                     }
-
                 }
         }
     }
@@ -293,30 +301,34 @@ struct YourApp: App {
 
 ### Storyboard Project
 
-For Storyboard apps, implement the `scene(_:continue:)` method in your `SceneDelegate` to handle Universal Links. Below is an example implementation in Storyboard.
+For Storyboard-based apps, you can handle incoming Short.io links (Universal Links) in your `SceneDelegate`. Implement the `scene(_:continue:)` method to capture the URL and pass it to the SDK for processing. Below is an example implementation in Storyboard.
 
 ```swift
 import UIKit
 import ShortIOSDK
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    
+
     private let sdk = ShortIOSDK.shared
-    
+
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
               let incomingURL = userActivity.webpageURL else {
             print("Invalid universal link or URL components")
             return
         }
-        sdk.handleOpen(incomingURL) { result in
-            switch result {
-                case .success(let result):
-                    // Handle successful URL processing
-                    print("result", result, "Host: \(result.host), Path: \(result.path)", "QueryParams: \(result.queryItems)")
-                case .failure(let error):
-                    // Handle error with proper error type
-                    print("Error: \(error.localizedDescription)")
+        Task {
+            do {
+                let components = try await sdk.handleOpen(incomingURL)
+                // Handle successful URL processing
+                print(
+                    "Original URL: \(components.url?.absoluteString ?? "unknown")",
+                    "Host: \(components.host ?? "nil"), Path: \(components.path)",
+                    "QueryParams: \(components.queryItems ?? [])"
+                )
+            } catch {
+                // Handle error with proper error type
+                print("Error: \(error.localizedDescription)")
             }
         }
     }
@@ -324,6 +336,32 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 ```
 ### Using the `handleOpen` Function
 
-The `handleOpen` function, provided by the SDK, processes a given URL and returns `URLComponents` if the URL is valid. It ensures proper parsing of universal links, checking for a valid scheme and returning all available components for further processing.
+```swift
+public func handleOpen(_ url: URL) async throws -> URLComponents
+```
+
+The `handleOpen` function, provided by the SDK, processes a given URL and returns `URLComponents` if the URL is valid. It ensures proper parsing of universal links, checking for a valid scheme and returning all available components for further processing. It also records the link's `clid`, so a later call to `trackConversion` can attribute the conversion without you passing it explicitly.
 
 You can access properties like `host`, `path`, `queryItems`, or other properties from the returned `URLComponents` to determine the appropriate navigation or action in your app.
+
+On failure it throws a `URLHandlerError` — for example `.invalidURLScheme` for a non-HTTP URL, `.linkNotValid` if the short link returns 404, or `.networkError` if the request fails.
+
+#### ⚠️ Deprecated: completion-handler variant
+
+```swift
+@available(*, deprecated, renamed: "handleOpen(_:)")
+@MainActor
+public func handleOpen(_ url: URL, completion: @escaping URLHandlerCompletion)
+```
+
+The completion-handler form still works and still delivers its result on the main thread, so existing integrations continue to compile and behave identically. It is deprecated as of `1.1.0` and **will be removed in `2.0.0`**. Xcode offers a fix-it to migrate to the `async` form above.
+
+### Swift 6 Support
+
+The SDK is built in Swift 6 language mode and is free of data-race diagnostics. `ShortIOSDK` conforms to `Sendable`, so you can hold and call it from any isolation context — including from a `@MainActor` type such as a SwiftUI view — without `@preconcurrency import` or `nonisolated(unsafe)`.
+
+Apps using Swift 5 language mode are unaffected and require no source changes.
+
+#### ⚠️ Minimum deployment target
+
+As of `1.1.0` the package declares a floor of **iOS 15.0 / macOS 12.0**. Earlier releases declared no floor and instead gated the individual `async` methods with `@available`, so an app targeting iOS 13 or 14 could link the SDK and use the completion-handler APIs. That is no longer possible — apps below iOS 15 must stay on `1.0.x`.

--- a/README.md
+++ b/README.md
@@ -369,4 +369,4 @@ Apps using Swift 5 language mode are unaffected and require no source changes.
 
 #### ⚠️ Minimum deployment target
 
-As of `1.1.0` the package declares a floor of **iOS 15.0 / macOS 12.0**. Earlier releases declared no floor and instead gated the individual `async` methods with `@available`, so an app targeting iOS 13 or 14 could link the SDK and use the completion-handler APIs. That is no longer possible — apps below iOS 15 must stay on `1.0.x`.
+As of `1.1.0` the package declares a floor of **iOS 15.0 / macOS 12.0**. Earlier releases declared no floor and instead gated the individual `async` methods with `@available`, so an app targeting iOS 13 or 14 could link the SDK and use the completion-handler APIs. That is no longer possible — apps below iOS 15.0 or macOS 12.0 must stay on `1.0.x`.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,12 @@ The `handleOpen` function, provided by the SDK, processes a given URL and return
 
 You can access properties like `host`, `path`, `queryItems`, or other properties from the returned `URLComponents` to determine the appropriate navigation or action in your app.
 
-On failure it throws a `URLHandlerError` — for example `.invalidURLScheme` for a non-HTTP URL, `.linkNotValid` if the short link returns 404, or `.networkError` if the request fails.
+On failure it throws a `URLHandlerError`:
+
+* `.invalidURLScheme` — the URL is not `http` or `https`.
+* `.linkNotValid` — the short link itself was not found (404, no redirect).
+* `.destinationUnavailable(statusCode:destination:)` — the short link resolved, but the page it points at returned a failure status. The link is fine; its destination is not.
+* `.networkError` — the request failed to complete.
 
 #### ⚠️ Deprecated: completion-handler variant
 

--- a/Sources/ShortIOSDK/Helpers/urlHandler.swift
+++ b/Sources/ShortIOSDK/Helpers/urlHandler.swift
@@ -1,14 +1,19 @@
 import Foundation
 
 // MARK: - Error Types
-public enum URLHandlerError: LocalizedError {
+public enum URLHandlerError: LocalizedError, Sendable {
+    @available(*, deprecated, message: "Never thrown. Superseded by ShortIOError.notInitialized. Removed in 2.0.0.")
     case notInitialized
     case invalidURL
     case invalidURLScheme
-    case networkError(Error)
+    case networkError(any Error & Sendable)
     case invalidServerResponse
     case invalidResponseURL
+    /// The short link itself was not found — the shortener returned 404 without redirecting.
     case linkNotValid
+    /// The short link resolved, but its destination answered with a failure status.
+    /// The link is fine; the page it points at is not.
+    case destinationUnavailable(statusCode: Int, destination: URL)
     case unexpectedStatusCode(Int)
     case unknownError
 
@@ -28,6 +33,8 @@ public enum URLHandlerError: LocalizedError {
             return "Invalid server response URL"
         case .linkNotValid:
             return "Link is not valid"
+        case .destinationUnavailable(let code, let destination):
+            return "Short link resolved to \(destination.absoluteString), which returned status \(code)"
         case .unexpectedStatusCode(let code):
             return "Unexpected status code: \(code)"
         case .unknownError:
@@ -64,8 +71,7 @@ extension URLComponents {
     }
 }
 
-class URLHandler {
-    @MainActor static let shared = URLHandler()
+final class URLHandler: Sendable {
     private let session: URLSession
 
     init(session: URLSession = .shared) {
@@ -73,7 +79,7 @@ class URLHandler {
     }
 
     func createURLComponents(from url: URL) throws -> URLComponents {
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               let scheme = components.scheme,
               ["http", "https"].contains(scheme.lowercased()) else {
             throw URLHandlerError.invalidURLScheme
@@ -88,26 +94,14 @@ class URLHandler {
 
         var request = URLRequest(url: url)
         request.httpMethod = "HEAD"
-        request.timeoutInterval = 30.0 // Add timeout for better UX
+        request.timeoutInterval = Constants.requestTimeout
         return request
     }
 
-    private func extractClid(from url: String) throws -> String? {
-        // Convert the URL string to a URL object
-        guard let url = URL(string: url) else {
-            throw URLHandlerError.invalidURL
-        }
-
-        // Parse the URL into components
-        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            throw URLHandlerError.invalidURL
-        }
-
-        // Extract the clid query parameter
-        return components.queryItems?.first(where: { $0.name == "clid" })?.value
-    }
-
-    private func processHTTPResponse(_ response: URLResponse?) throws -> URLComponents {
+    /// - Parameter requestedURL: The short link that was requested. `URLSession` follows redirects,
+    ///   so a failure status may belong to the destination rather than to the short link itself;
+    ///   comparing the two is what tells them apart.
+    private func processHTTPResponse(_ response: URLResponse?, requestedURL: URL?) throws -> URLComponents {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLHandlerError.invalidServerResponse
         }
@@ -120,12 +114,17 @@ class URLHandler {
             throw URLHandlerError.invalidResponseURL
         }
 
+        // A redirect means the shortener resolved the link and we are now looking at the
+        // destination's response, so its status must not be blamed on the short link.
+        let didRedirect = requestedURL.map { responseURL.absoluteString != $0.absoluteString } ?? false
+
         // Process based on status code
         switch httpResponse.statusCode {
         case 200:
             responseComponents.removeUTMMedium()
-            print("Short SDK click call completed successfully")
             return responseComponents
+        case let code where didRedirect:
+            throw URLHandlerError.destinationUnavailable(statusCode: code, destination: responseURL)
         case 404:
             throw URLHandlerError.linkNotValid
         default:
@@ -134,50 +133,31 @@ class URLHandler {
     }
 
     // MARK: - Public Methods
+    /// Performs the click request and returns the processed components plus any `clid`.
     func handleClick(
-        urlComponents: URLComponents,
-        completion: @escaping URLHandlerCompletion,
-        clidHandler: @escaping (String?) -> Void
-    ) {
+        urlComponents: URLComponents
+    ) async throws -> (components: URLComponents, clid: String?) {
 
         // Prepare components with UTM parameter
         var components = urlComponents
         components.addUTMMediumIOS()
 
-        // Create request
-        let request: URLRequest
+        let request = try createURLRequest(from: components)
+
+        let response: URLResponse
         do {
-            request = try createURLRequest(from: components)
+            (_, response) = try await session.data(for: request)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            // URLSession reports cancellation as URLError(.cancelled), which is not a network failure.
+            throw CancellationError()
         } catch {
-            completion(.failure((error as? URLHandlerError) ?? .unknownError))
-            return
+            throw URLHandlerError.networkError(error as NSError)
         }
 
-        // Execute network request
-        session.dataTask(with: request) { [weak self] _, response, error in
-            DispatchQueue.main.async {
-                if let error = error {
-                    completion(.failure(.networkError(error)))
-                    return
-                }
-
-                do {
-                    let processedComponents = try self?.processHTTPResponse(response) ?? {
-                        throw URLHandlerError.unknownError
-                    }()
-
-                    // Extract `clid` from processedComponents if available
-                    let clid = processedComponents.queryItems?.first(where: { $0.name == "clid" })?.value
-                    clidHandler(clid)
-                    completion(.success(processedComponents))
-                } catch {
-                    if let urlHandlerError = error as? URLHandlerError {
-                        completion(.failure(urlHandlerError))
-                    } else {
-                        completion(.failure(.unknownError))
-                    }
-                }
-            }
-        }.resume()
+        let processedComponents = try processHTTPResponse(response, requestedURL: request.url)
+        let clid = processedComponents.queryItems?.first(where: { $0.name == "clid" })?.value
+        return (processedComponents, clid)
     }
 }

--- a/Sources/ShortIOSDK/Helpers/urlHandler.swift
+++ b/Sources/ShortIOSDK/Helpers/urlHandler.swift
@@ -116,7 +116,15 @@ final class URLHandler: Sendable {
 
         // A redirect means the shortener resolved the link and we are now looking at the
         // destination's response, so its status must not be blamed on the short link.
-        let didRedirect = requestedURL.map { responseURL.absoluteString != $0.absoluteString } ?? false
+        //
+        // Compared on scheme/host/path only: the query is not identity here. This request
+        // carries an appended `utm_medium`, and servers may canonicalise the query on the way
+        // back, so comparing whole URLs reports a redirect that never happened.
+        let didRedirect = requestedURL.map { requested in
+            responseURL.scheme?.lowercased() != requested.scheme?.lowercased()
+                || responseURL.host?.lowercased() != requested.host?.lowercased()
+                || responseURL.path != requested.path
+        } ?? false
 
         // Process based on status code
         switch httpResponse.statusCode {

--- a/Sources/ShortIOSDK/Internal/Config.swift
+++ b/Sources/ShortIOSDK/Internal/Config.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// The SDK's mutable configuration, grouped so one lock guards one value.
+struct Config: Sendable {
+    var session: URLSession = .shared
+    var isInitialized: Bool = false
+    var apiKey: String = ""
+    var domain: String = ""
+    var clid: String = ""
+}

--- a/Sources/ShortIOSDK/Internal/LockedState.swift
+++ b/Sources/ShortIOSDK/Internal/LockedState.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A `Sendable` box guarding a value with an `NSLock`. Swapping in `Mutex` later
+/// means changing this file only.
+final class LockedState<Value>: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    /// Runs `body` with exclusive access to the stored value.
+    func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+}

--- a/Sources/ShortIOSDK/Models/ShortIOErrorResponse.swift
+++ b/Sources/ShortIOSDK/Models/ShortIOErrorResponse.swift
@@ -1,4 +1,4 @@
-public struct ShortIOErrorResponse: Decodable {
+public struct ShortIOErrorResponse: Decodable, Sendable {
     public let message: String
     public let code: String?
     public let statusCode: Int

--- a/Sources/ShortIOSDK/Models/ShortIOParameters.swift
+++ b/Sources/ShortIOSDK/Models/ShortIOParameters.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum IntOrString: Encodable {
+public enum IntOrString: Encodable, Sendable {
     case int(Int)
     case string(String)
     
@@ -15,8 +15,16 @@ public enum IntOrString: Encodable {
     }
 }
 
-public struct ShortIOParameters: Encodable {
-    public var domain: String?
+public struct ShortIOParameters: Encodable, Sendable {
+    /// Backing storage, so the SDK does not trigger its own deprecation warning.
+    var _domain: String?
+
+    @available(*, deprecated, message: "'domain' is supplied by initialize(apiKey:domain:) and will be removed in 2.0.0. Set it here only to override that for a single call.")
+    public var domain: String? {
+        get { _domain }
+        set { _domain = newValue }
+    }
+
     public let originalURL: String
     public var cloaking: Bool?
     public var password: String?
@@ -79,7 +87,7 @@ public struct ShortIOParameters: Encodable {
         integrationGTM: String? = nil,
         folderId: String? = nil
     ) {
-        self.domain = domain
+        self._domain = domain
         self.originalURL = originalURL
         self.cloaking = cloaking
         self.password = password
@@ -112,7 +120,7 @@ public struct ShortIOParameters: Encodable {
     }
     
     private enum CodingKeys: String, CodingKey {
-        case domain
+        case _domain = "domain"
         case originalURL
         case cloaking
         case password

--- a/Sources/ShortIOSDK/Models/ShortIOResponse.swift
+++ b/Sources/ShortIOSDK/Models/ShortIOResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct ShortIOResponse: Decodable {
+public struct ShortIOResponse: Decodable, Sendable {
     public let originalURL: String
     public let path: String
     public let idString: String

--- a/Sources/ShortIOSDK/Models/User.swift
+++ b/Sources/ShortIOSDK/Models/User.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct User: Decodable {
+public struct User: Decodable, Sendable {
     public let id: Int
     public let name: String
     public let email: String

--- a/Sources/ShortIOSDK/ShortIOSDK.swift
+++ b/Sources/ShortIOSDK/ShortIOSDK.swift
@@ -1,20 +1,14 @@
 import Foundation
 import CryptoKit
 
-public class ShortIOSDK {
-    @MainActor public static let shared = ShortIOSDK()
+public final class ShortIOSDK: Sendable {
+    public static let shared = ShortIOSDK()
 
     // MARK: - Private Properties
-    private var session: URLSession
-    private var isInitialized = false
-    private var apiKey: String = ""
-    private var domain: String = ""
-    private var clid: String = ""
+    private let state = LockedState(Config())
 
-    // MARK: - Private Initializer
-    private init() {
-        self.session = .shared
-    }
+    // MARK: - Initializer
+    init() {}
 
     // MARK: - Public Initialization
     /// Initialize the SDK with required API key and domain
@@ -24,20 +18,32 @@ public class ShortIOSDK {
     ///   - session: Custom URLSession (defaults to shared session)
     /// - Note: This method should be called once before using any SDK functionality
     public func initialize(session: URLSession = .shared, apiKey: String, domain: String) {
-        if !isInitialized {
-            self.session = session
-            self.apiKey = apiKey
-            self.domain = domain
-            self.isInitialized = true
-        } else {
-            print("SDK is already initialized.")
-            return
+        state.withLock { config in
+            // Subsequent calls are ignored; the first configuration wins.
+            guard !config.isInitialized else { return }
+            config.session = session
+            config.apiKey = apiKey
+            config.domain = domain
+            config.isInitialized = true
         }
+
     }
 
-    @available(macOS 12.0, iOS 15.0, *)
+    // MARK: - Internal Test Accessors
+    var clidForTesting: String { state.withLock { $0.clid } }
+    var apiKeyForTesting: String { state.withLock { $0.apiKey } }
+    var domainForTesting: String { state.withLock { $0.domain } }
+    func setClidForTesting(_ clid: String) { state.withLock { $0.clid = clid } }
+
+    /// Throws `.notInitialized` unless `initialize(apiKey:domain:)` has been called.
+    private func ensureInitialized() throws {
+        let isInitialized = state.withLock { $0.isInitialized }
+        guard isInitialized else { throw ShortIOError.notInitialized }
+    }
 
     private func performCreateShortLink(parameters: ShortIOParameters, apiKey: String?) async throws -> ShortIOResult {
+        let (session, configuredDomain) = state.withLock { ($0.session, $0.domain) }
+
         guard let url = URL(string: Constants.baseURL) else {
             throw ShortIOError.invalidURL
         }
@@ -50,41 +56,44 @@ public class ShortIOSDK {
 
         var finalParameters = parameters
 
-        finalParameters.domain = parameters.domain != nil ? parameters.domain : self.domain
+        // The API requires `domain` and never derives it from the key. Fall back to the
+        // configured one; leave validating it to the API.
+        finalParameters._domain = parameters._domain ?? configuredDomain
 
         request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue(apiKey ?? "", forHTTPHeaderField: "Authorization")
 
-        do {
-            // Encode request parameters
-            request.httpBody = try JSONEncoder().encode(finalParameters)
+        // Encode request parameters
+        request.httpBody = try JSONEncoder().encode(finalParameters)
 
-            // Execute network request
-            let (data, response) = try await session.data(for: request)
+        // Execute network request
+        let (data, response) = try await session.data(for: request)
 
-            // Validate HTTP response
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw ShortIOError.invalidResponse
-            }
+        // Validate HTTP response
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ShortIOError.invalidResponse
+        }
 
-            // Handle HTTP status codes
-            guard (200...299).contains(httpResponse.statusCode) else {
+        // Handle HTTP status codes
+        guard (200...299).contains(httpResponse.statusCode) else {
 
-                // Error responses
-                let errorResponse = try JSONDecoder().decode(ShortIOErrorResponse.self, from: data)
+            // Decode leniently: a non-JSON body must not escalate into a thrown error.
+            if let errorResponse = try? JSONDecoder().decode(ShortIOErrorResponse.self, from: data) {
                 return .failure(errorResponse)
             }
-
-            // Success range
-            let successResponse = try JSONDecoder().decode(ShortIOResponse.self, from: data)
-            return .success(successResponse)
-        } catch {
-
-            // Propagate encoding/decoding/network errors
-            throw error
+            return .failure(ShortIOErrorResponse(
+                message: "Request failed with status code \(httpResponse.statusCode).",
+                code: nil,
+                statusCode: httpResponse.statusCode,
+                success: false
+            ))
         }
+
+        // Success range
+        let successResponse = try JSONDecoder().decode(ShortIOResponse.self, from: data)
+        return .success(successResponse)
     }
 
     /// Creates a shortened link using Short.io API
@@ -92,119 +101,148 @@ public class ShortIOSDK {
     ///   - parameters: Configuration for the shortened link
     ///   - apiKey: Authentication key for Short.io API
     /// - Returns: Result containing either success response or error
-    @available(*, deprecated, message: "Parameter 'apiKey' is deprecated. Use the instance's configured API key instead. Call initialize(apiKey:domain:) before using this method")
-    @available(macOS 12.0, iOS 15.0, *)
+    @available(*, deprecated, renamed: "createShortLink(parameters:)",
+               message: "Parameter 'apiKey' is deprecated. Call initialize(apiKey:domain:) first, then use createShortLink(parameters:). This overload will be removed in 2.0.0.")
     public func createShortLink(
         parameters: ShortIOParameters,
         apiKey: String? = nil
     ) async throws -> ShortIOResult {
 
-        // Safely construct API endpoint URL
+        // Skips `ensureInitialized()`: this overload takes `apiKey` directly.
         return try await performCreateShortLink(parameters: parameters, apiKey: apiKey)
 
     }
 
-    @available(macOS 12.0, iOS 15.0, *)
     public func createShortLink(
         parameters: ShortIOParameters
     ) async throws -> ShortIOResult {
 
+        try ensureInitialized()
+
         // Safely construct API endpoint URL
-        return try await performCreateShortLink(parameters: parameters, apiKey: self.apiKey)
+        return try await performCreateShortLink(
+            parameters: parameters,
+            apiKey: state.withLock { $0.apiKey }
+        )
     }
 
-    @available(macOS 12.0, iOS 15.0, *)
     public func createSecure(originalURL: String) throws -> (securedOriginalURL: String, securedShortUrl: String) {
 
-        do {
-            // Generate a 128-bit AES-GCM key
-            let key = SymmetricKey(size: .bits128)
+        // Generate a 128-bit AES-GCM key
+        let key = SymmetricKey(size: .bits128)
 
-            // Generate a 12-byte nonce (IV)
-            let nonce = AES.GCM.Nonce()
+        // Generate a 12-byte nonce (IV)
+        let nonce = AES.GCM.Nonce()
 
-            // Encrypt the original URL
-            guard let urlData = originalURL.data(using: .utf8) else {
-                throw ShortIOError.invalidURL
-            }
-            let sealedBox = try AES.GCM.seal(urlData, using: key, nonce: nonce)
-
-            // Encode encrypted data and nonce to Base64
-            let encryptedUrlBase64 = sealedBox.ciphertext.base64EncodedString()
-            let nonceBase64 = sealedBox.nonce.withUnsafeBytes { Data($0).base64EncodedString() }
-
-            // Construct secured URL
-            let securedOriginalURL = "shortsecure://\(encryptedUrlBase64)?\(nonceBase64)"
-
-            // Export key as Base64
-            let keyData = key.withUnsafeBytes { Data($0) }
-            let keyBase64 = keyData.base64EncodedString()
-            let securedShortUrl = "#\(keyBase64)"
-
-            return (securedOriginalURL, securedShortUrl)
-        } catch {
-            throw error
+        // Encrypt the original URL
+        guard let urlData = originalURL.data(using: .utf8) else {
+            throw ShortIOError.invalidURL
         }
+        let sealedBox = try AES.GCM.seal(urlData, using: key, nonce: nonce)
+
+        // Encode encrypted data and nonce to Base64
+        let encryptedUrlBase64 = sealedBox.ciphertext.base64EncodedString()
+        let nonceBase64 = sealedBox.nonce.withUnsafeBytes { Data($0).base64EncodedString() }
+
+        // Construct secured URL
+        let securedOriginalURL = "shortsecure://\(encryptedUrlBase64)?\(nonceBase64)"
+
+        // Export key as Base64
+        let keyData = key.withUnsafeBytes { Data($0) }
+        let keyBase64 = keyData.base64EncodedString()
+        let securedShortUrl = "#\(keyBase64)"
+
+        return (securedOriginalURL, securedShortUrl)
     }
 
-    @available(macOS 12.0, iOS 15.0, *)
-    public func trackConversion(clid: String? = nil, domain: String? = nil, conversionId: String? = nil) async throws -> Bool {
+    /// Records a conversion for a link previously resolved by `handleOpen(_:)`.
+    ///
+    /// The `clid` captured during `handleOpen(_:)` and the domain supplied to
+    /// `initialize(apiKey:domain:)` are used automatically.
+    /// - Parameter conversionId: Optional identifier for the conversion event.
+    /// - Returns: `true` if the conversion request succeeded.
+    public func trackConversion(conversionId: String? = nil) async throws -> Bool {
+        try ensureInitialized()
+        return try await performTrackConversion(clid: nil, domain: nil, conversionId: conversionId)
+    }
 
-        // Create the base URL by removing trailing slash if exists
+    @available(*, deprecated, renamed: "trackConversion(conversionId:)",
+               message: "'clid' is captured by handleOpen(_:) and 'domain' by initialize(apiKey:domain:), so neither needs to be passed. This overload will be removed in 2.0.0.")
+    public func trackConversion(clid: String?, domain: String? = nil, conversionId: String? = nil) async throws -> Bool {
+        // Skips `ensureInitialized()`: this overload takes `clid`/`domain` directly.
+        return try await performTrackConversion(clid: clid, domain: domain, conversionId: conversionId)
+    }
 
-        let domainToUse = domain ?? self.domain
-        let trimmedDomain = domainToUse.trimmingCharacters(in: ["/"])
-        let finalDomain = trimmedDomain ?? ""
+    private func performTrackConversion(clid: String?, domain: String?, conversionId: String?) async throws -> Bool {
 
-        let finalClid = clid ?? self.clid
-
-        // Construct the conversion path with clid parameter
-        var conversionURLString = "https://\(finalDomain)/.shortio/conversion?clid=\(finalClid)"
-
-        if let conversionId = conversionId {
-            conversionURLString += "&c=\(conversionId)"
+        let (session, configuredDomain, storedClid) = state.withLock {
+            ($0.session, $0.domain, $0.clid)
         }
+        let domainToUse = domain ?? configuredDomain
+        let finalDomain = domainToUse.trimmingCharacters(in: ["/"])
+        let finalClid = clid ?? storedClid
 
-        guard let url = URL(string: conversionURLString) else {
-            print("Invalid URL constructed: \(conversionURLString)")
+        // Without a clid the endpoint can only fail, and handleOpen(_:) is what records one.
+        guard !finalClid.trimmingCharacters(in: .whitespaces).isEmpty,
+              !finalDomain.trimmingCharacters(in: .whitespaces).isEmpty else {
             return false
         }
 
-        do {
-            let (data, response) = try await session.data(from: url)
-
-            guard let httpResponse = response as? HTTPURLResponse else {
-                print("Invalid response type")
-                return false
-            }
-
-            // Return true only for successful status codes (typically 200-299)
-            return (200...299).contains(httpResponse.statusCode)
-
-        } catch {
-            throw error
+        // Query items percent-encode reserved characters, which interpolation would not.
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = finalDomain
+        components.path = "/.shortio/conversion"
+        var queryItems: [URLQueryItem] = [URLQueryItem(name: "clid", value: finalClid)]
+        if let conversionId {
+            queryItems.append(URLQueryItem(name: "c", value: conversionId))
         }
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw ShortIOError.invalidURL
+        }
+
+        let (_, response) = try await session.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ShortIOError.invalidResponse
+        }
+
+        // Return true only for successful status codes (typically 200-299)
+        return (200...299).contains(httpResponse.statusCode)
     }
 
+    /// Resolves an incoming Short.io link, recording its `clid` for conversion tracking.
+    /// - Parameter url: The universal link the app was opened with.
+    /// - Returns: The processed URL components of the destination.
+    /// - Throws: `URLHandlerError` if the scheme is unsupported or the request fails.
+    public func handleOpen(_ url: URL) async throws -> URLComponents {
+        let session = state.withLock { $0.session }
+        let handler = URLHandler(session: session)
+
+        let components = try handler.createURLComponents(from: url)
+        let (processedComponents, clid) = try await handler.handleClick(urlComponents: components)
+
+        if let clid {
+            state.withLock { $0.clid = clid }
+        }
+
+        return processedComponents
+    }
+
+    @available(*, deprecated, renamed: "handleOpen(_:)",
+               message: "Use the async handleOpen(_:) instead. This overload will be removed in 2.0.0.")
     @MainActor
     public func handleOpen(_ url: URL, completion: @escaping URLHandlerCompletion) {
-        // Validation
-        do {
-            var handler = URLHandler.shared
-            let components = try handler.createURLComponents(from: url)
-
-            handler.handleClick(urlComponents: components, completion: completion) { clid in
-                if let clid = clid {
-                    self.clid = clid
-                }
-            }
-        } catch {
-            //            completion(.failure(error as! URLHandlerError))
-            if let urlHandlerError = error as? URLHandlerError {
-                completion(.failure(urlHandlerError))
-            } else {
-                // Provide a fallback error; you may want to define a .unknown case in URLHandlerError
-                completion(.failure(URLHandlerError.unknownError))
+        Task { @MainActor in
+            do {
+                let components = try await handleOpen(url)
+                completion(.success(components))
+            } catch let error as URLHandlerError {
+                completion(.failure(error))
+            } catch {
+                completion(.failure(.unknownError))
             }
         }
     }
@@ -212,14 +250,15 @@ public class ShortIOSDK {
 
 // MARK: - Result Type
 /// Result type for Short.io API operations
-public enum ShortIOResult {
+public enum ShortIOResult: Sendable {
     case success(ShortIOResponse)
     case failure(ShortIOErrorResponse)
 }
 
 // MARK: - Error Handling
 /// Custom errors for Short.io operations
-public enum ShortIOError: Error {
+public enum ShortIOError: Error, Sendable {
+    case notInitialized
     case invalidURL
     case invalidResponse
 }
@@ -228,6 +267,8 @@ public enum ShortIOError: Error {
 extension ShortIOError: LocalizedError {
     public var errorDescription: String? {
         switch self {
+        case .notInitialized:
+            return "SDK not initialized. Call initialize(apiKey:domain:) first."
         case .invalidURL:
             return "Invalid URL"
         case .invalidResponse:

--- a/Tests/ShortIOSDKTests/ConcurrencyTests.swift
+++ b/Tests/ShortIOSDKTests/ConcurrencyTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+struct ConcurrencyTests {
+
+    /// Compiles only if `ShortIOSDK` is `Sendable` — the property consumers need.
+    @Test func sdkIsSendable() {
+        func requireSendable<T: Sendable>(_ type: T.Type) {}
+        requireSendable(ShortIOSDK.self)
+    }
+
+    @Test func concurrentConfigurationAccessIsRaceFree() async {
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "key", domain: "example.com")
+
+        // Many tasks reading and writing the same storage simultaneously.
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<200 {
+                group.addTask {
+                    if index.isMultiple(of: 2) {
+                        sdk.setClidForTesting("clid-\(index)")
+                    } else {
+                        _ = sdk.clidForTesting
+                    }
+                }
+            }
+        }
+
+        #expect(sdk.clidForTesting.hasPrefix("clid-"))
+    }
+
+    @Test func initializeIsAppliedOnlyOnce() {
+        let sdk = ShortIOSDK()
+
+        sdk.initialize(apiKey: "first", domain: "first.example")
+        sdk.initialize(apiKey: "second", domain: "second.example")
+
+        #expect(sdk.apiKeyForTesting == "first")
+        #expect(sdk.domainForTesting == "first.example")
+    }
+}

--- a/Tests/ShortIOSDKTests/CreateSecureTests.swift
+++ b/Tests/ShortIOSDKTests/CreateSecureTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+struct CreateSecureTests {
+
+    @Test func securedURLUsesShortsecureSchemeAndBase64Parts() throws {
+        let sdk = ShortIOSDK()
+
+        let result = try sdk.createSecure(originalURL: "https://example.com/page")
+
+        #expect(result.securedOriginalURL.hasPrefix("shortsecure://"))
+        #expect(result.securedShortUrl.hasPrefix("#"))
+
+        // Body is "<ciphertext>?<nonce>", both Base64.
+        let body = result.securedOriginalURL.replacingOccurrences(of: "shortsecure://", with: "")
+        let parts = body.split(separator: "?")
+        #expect(parts.count == 2)
+        #expect(Data(base64Encoded: String(parts[0])) != nil)
+        #expect(Data(base64Encoded: String(parts[1])) != nil)
+
+        // Key is a 128-bit AES key, Base64 of 16 bytes.
+        let keyBase64 = String(result.securedShortUrl.dropFirst())
+        #expect(Data(base64Encoded: keyBase64)?.count == 16)
+    }
+}

--- a/Tests/ShortIOSDKTests/CreateShortLinkTests.swift
+++ b/Tests/ShortIOSDKTests/CreateShortLinkTests.swift
@@ -1,0 +1,97 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Serialized: every test posts to the same endpoint, and `URLProtocolStub` keys its registry
+/// by host + path, so parallel runs would overwrite each other's stubs.
+@Suite(.serialized)
+struct CreateShortLinkTests {
+
+    /// The single endpoint all create-link requests hit.
+    private let endpoint = URL(string: "https://api.short.io/links/public")!
+
+    /// A minimal valid success body — enough for `ShortIOResponse` to decode.
+    private func successBody() throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "originalURL": "https://long.example/page",
+            "path": "/abc",
+            "idString": "id-str",
+            "id": "abc",
+            "shortURL": "https://example.com/abc",
+            "secureShortURL": "https://example.com/secure",
+            "cloaking": false,
+            "tags": [],
+            "createdAt": "2024-01-01T00:00:00Z",
+            "skipQS": false,
+            "archived": false,
+            "DomainId": 42,
+            "OwnerId": 7,
+            "hasPassword": false,
+            "source": "api",
+            "success": true,
+            "duplicate": false
+        ])
+    }
+
+    @Test func parametersWithoutDomainFallBackToConfiguredDomain() async throws {
+        URLProtocolStub.register(.init(statusCode: 200, url: endpoint, body: try successBody()))
+
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "sk_test_key", domain: "configured.example")
+
+        _ = try await sdk.createShortLink(parameters: ShortIOParameters(originalURL: "https://long.example/page"))
+
+        let captured = try #require(URLProtocolStub.capturedRequest(for: endpoint))
+        let body = try #require(captured.body)
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        #expect(json["domain"] as? String == "configured.example")
+    }
+
+    /// Body captured verbatim from the live API for `"domain": ""`. The SDK must forward it
+    /// rather than substitute an error of its own.
+    @Test func serverDomainValidationErrorIsForwardedVerbatim() async throws {
+        URLProtocolStub.register(.init(
+            statusCode: 400,
+            url: endpoint,
+            body: Data(#"{"message":"domain must match format \"hostname\"","statusCode":400,"code":"FST_ERR_VALIDATION","success":false}"#.utf8)
+        ))
+
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "sk_test_key", domain: "")
+
+        let result = try await sdk.createShortLink(
+            parameters: ShortIOParameters(originalURL: "https://long.example/page")
+        )
+
+        guard case .failure(let error) = result else {
+            Issue.record("expected .failure, got \(result)")
+            return
+        }
+        #expect(error.statusCode == 400)
+        #expect(error.message == #"domain must match format "hostname""#)
+        // The server's error code must survive — a locally synthesised failure would drop it.
+        #expect(error.code == "FST_ERR_VALIDATION")
+    }
+
+    /// A non-JSON error body must still surface as a structured failure rather than throwing.
+    @Test func nonJSONErrorBodyFallsBackToStatusCodeFailure() async throws {
+        URLProtocolStub.register(.init(
+            statusCode: 502,
+            url: endpoint,
+            body: Data("<html><body>Bad Gateway</body></html>".utf8)
+        ))
+
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "sk_test_key", domain: "configured.example")
+
+        let result = try await sdk.createShortLink(
+            parameters: ShortIOParameters(originalURL: "https://long.example/page")
+        )
+
+        guard case .failure(let error) = result else {
+            Issue.record("expected .failure, got \(result)")
+            return
+        }
+        #expect(error.statusCode == 502)
+    }
+}

--- a/Tests/ShortIOSDKTests/HandleOpenTests.swift
+++ b/Tests/ShortIOSDKTests/HandleOpenTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+struct HandleOpenTests {
+
+    private func makeSDK() -> ShortIOSDK {
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "key", domain: "example.com")
+        return sdk
+    }
+
+    @Test func asyncHandleOpenReturnsProcessedComponents() async throws {
+        URLProtocolStub.register(
+            .init(statusCode: 200, url: URL(string: "https://example.com/open/ok?clid=xyz123")!)
+        )
+        let sdk = makeSDK()
+
+        let components = try await sdk.handleOpen(URL(string: "https://example.com/open/ok")!)
+
+        #expect(components.host == "example.com")
+        #expect(components.path == "/open/ok")
+    }
+
+    @Test func asyncHandleOpenStoresClidForLaterConversionTracking() async throws {
+        URLProtocolStub.register(
+            .init(statusCode: 200, url: URL(string: "https://example.com/open/store?clid=stored-clid")!)
+        )
+        let sdk = makeSDK()
+
+        _ = try await sdk.handleOpen(URL(string: "https://example.com/open/store")!)
+
+        #expect(sdk.clidForTesting == "stored-clid")
+    }
+
+    /// The deprecated overload must produce the same result as the async one,
+    /// and must deliver it on the main thread.
+    @MainActor
+    @Test
+    @available(*, deprecated, message: "Intentionally exercises the deprecated overload.")
+    func deprecatedOverloadMatchesAsyncAndDeliversOnMain() async throws {
+        URLProtocolStub.register(
+            .init(statusCode: 200, url: URL(string: "https://example.com/open/deprecated?clid=xyz123")!)
+        )
+        let sdk = makeSDK()
+
+        let expected = try await sdk.handleOpen(URL(string: "https://example.com/open/deprecated")!)
+
+        let received: URLComponents? = await withCheckedContinuation { continuation in
+            sdk.handleOpen(URL(string: "https://example.com/open/deprecated")!) { result in
+                #expect(Thread.isMainThread)
+                switch result {
+                case .success(let components): continuation.resume(returning: components)
+                case .failure: continuation.resume(returning: nil)
+                }
+            }
+        }
+
+        #expect(received?.host == expected.host)
+        #expect(received?.path == expected.path)
+    }
+}

--- a/Tests/ShortIOSDKTests/InitializationTests.swift
+++ b/Tests/ShortIOSDKTests/InitializationTests.swift
@@ -1,0 +1,32 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Without `initialize(apiKey:domain:)`, network entry points must throw `.notInitialized`
+/// rather than send an empty Authorization header.
+struct InitializationTests {
+
+    @Test func createShortLinkThrowsNotInitializedWhenInitializeNotCalled() async {
+        let sdk = ShortIOSDK()
+        do {
+            _ = try await sdk.createShortLink(parameters: ShortIOParameters(originalURL: "https://example.com"))
+            Issue.record("createShortLink should throw when the SDK is not initialized")
+        } catch ShortIOError.notInitialized {
+            // expected
+        } catch {
+            Issue.record("Expected .notInitialized, got \(error)")
+        }
+    }
+
+    @Test func trackConversionThrowsNotInitializedWhenInitializeNotCalled() async {
+        let sdk = ShortIOSDK()
+        do {
+            _ = try await sdk.trackConversion()
+            Issue.record("trackConversion should throw when the SDK is not initialized")
+        } catch ShortIOError.notInitialized {
+            // expected
+        } catch {
+            Issue.record("Expected .notInitialized, got \(error)")
+        }
+    }
+}

--- a/Tests/ShortIOSDKTests/SendableConformanceTests.swift
+++ b/Tests/ShortIOSDKTests/SendableConformanceTests.swift
@@ -1,0 +1,19 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Compiles only if `T` conforms to `Sendable`.
+private func requireSendable<T: Sendable>(_ type: T.Type) {}
+
+struct SendableConformanceTests {
+
+    @Test func publicTypesAreSendable() {
+        requireSendable(ShortIOResponse.self)
+        requireSendable(ShortIOErrorResponse.self)
+        requireSendable(User.self)
+        requireSendable(ShortIOParameters.self)
+        requireSendable(IntOrString.self)
+        requireSendable(ShortIOResult.self)
+        requireSendable(ShortIOError.self)
+    }
+}

--- a/Tests/ShortIOSDKTests/ShortIOParametersEncodingTests.swift
+++ b/Tests/ShortIOSDKTests/ShortIOParametersEncodingTests.swift
@@ -1,0 +1,18 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Regression guard for the `domain` → `_domain` storage change.
+struct ShortIOParametersEncodingTests {
+
+    @Test func domainEncodesUnderDomainKey() throws {
+        let parameters = ShortIOParameters(domain: "demo.short.io", originalURL: "https://long.example/page")
+
+        let data = try JSONEncoder().encode(parameters)
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+
+        // The internal `_domain` storage must stay invisible on the wire.
+        #expect(json["domain"] as? String == "demo.short.io")
+        #expect(json["_domain"] == nil)
+    }
+}

--- a/Tests/ShortIOSDKTests/TrackConversionTests.swift
+++ b/Tests/ShortIOSDKTests/TrackConversionTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Covers the premise of the new `trackConversion(conversionId:)` overload: the `clid` no
+/// longer has to be passed, because `handleOpen(_:)` records it.
+struct TrackConversionTests {
+
+    private func conversionURL(domain: String) -> URL {
+        URL(string: "https://\(domain)/.shortio/conversion")!
+    }
+
+    @Test func usesClidCapturedByHandleOpenWhenNoneIsPassed() async throws {
+        let domain = "capture.example"
+        let landingURL = URL(string: "https://\(domain)/landing?clid=stored-clid")!
+        // The click request during handleOpen.
+        URLProtocolStub.register(.init(statusCode: 200, url: landingURL))
+        // The conversion request afterwards.
+        URLProtocolStub.register(.init(statusCode: 200, url: conversionURL(domain: domain)))
+
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "sk_test_key", domain: domain)
+
+        _ = try await sdk.handleOpen(URL(string: "https://\(domain)/landing")!)
+
+        let succeeded = try await sdk.trackConversion()
+
+        let captured = try #require(URLProtocolStub.capturedRequest(for: conversionURL(domain: domain)))
+        #expect(captured.url?.query?.contains("clid=stored-clid") == true)
+        #expect(succeeded)
+    }
+
+    /// Regression for #5: `conversionId` (and `clid`) must be percent-encoded, so reserved
+    /// characters cannot break out of their query slot.
+    @Test func conversionIdAndClidArePercentEncoded() async throws {
+        let domain = "encode.example"
+        URLProtocolStub.register(.init(statusCode: 200, url: conversionURL(domain: domain)))
+
+        let sdk = ShortIOSDK()
+        sdk.initialize(session: URLProtocolStub.session(), apiKey: "sk_test_key", domain: domain)
+        sdk.setClidForTesting("stored clid") // space must be encoded
+
+        _ = try await sdk.trackConversion(conversionId: "a&b=c") // all reserved
+
+        let captured = try #require(URLProtocolStub.capturedRequest(for: conversionURL(domain: domain)))
+        let query = try #require(captured.url?.query)
+        // clid value "stored clid" must not appear raw; its encoded form must.
+        #expect(query.contains("clid=stored%20clid"))
+        #expect(query.contains("c=a%26b%3Dc"))
+        // The raw reserved characters must not leak through.
+        #expect(!query.contains("clid=stored clid"))
+        #expect(!query.contains("&c=a&b=c"))
+    }
+}

--- a/Tests/ShortIOSDKTests/URLHandlerTests.swift
+++ b/Tests/ShortIOSDKTests/URLHandlerTests.swift
@@ -1,0 +1,78 @@
+import Testing
+import Foundation
+@testable import ShortIOSDK
+
+/// Smoke coverage that error mapping survived the rewrite of `handleClick` from
+/// `dataTask` + `DispatchQueue.main.async` to `async`/`await`.
+struct URLHandlerTests {
+
+    private func makeComponents(_ string: String) throws -> URLComponents {
+        let handler = URLHandler(session: URLProtocolStub.session())
+        return try handler.createURLComponents(from: URL(string: string)!)
+    }
+
+    @Test func notFoundMapsToLinkNotValid() async throws {
+        URLProtocolStub.register(.init(statusCode: 404, url: URL(string: "https://example.com/click/missing")!))
+        let handler = URLHandler(session: URLProtocolStub.session())
+        let components = try makeComponents("https://example.com/click/missing")
+
+        await #expect(throws: URLHandlerError.self) {
+            try await handler.handleClick(urlComponents: components)
+        }
+    }
+
+    /// A 404 reached *after* a redirect belongs to the destination, not to the short link.
+    /// Reporting it as `.linkNotValid` sends callers hunting for a bad short link that is fine.
+    @Test func notFoundAfterRedirectMapsToDestinationUnavailable() async throws {
+        let shortLink = URL(string: "https://example.com/click/live")!
+        let destination = URL(string: "https://example.com/your/long/url?clid=abc")!
+        // responseURL is the post-redirect URL, which is what URLSession surfaces once it
+        // has followed the shortener's 302.
+        URLProtocolStub.register(.init(statusCode: 404, url: shortLink, responseURL: destination))
+        let handler = URLHandler(session: URLProtocolStub.session())
+        let components = try makeComponents(shortLink.absoluteString)
+
+        do {
+            _ = try await handler.handleClick(urlComponents: components)
+            Issue.record("expected handleClick to throw")
+        } catch let error as URLHandlerError {
+            guard case .destinationUnavailable(let statusCode, let url) = error else {
+                Issue.record("expected .destinationUnavailable, got \(error)")
+                return
+            }
+            #expect(statusCode == 404)
+            #expect(url == destination)
+        }
+    }
+
+    /// `URLSession` reports task cancellation as `URLError(.cancelled)`. It must surface as
+    /// `CancellationError`, not be flattened into `.networkError` alongside real failures.
+    @Test func cancellationIsNotReportedAsANetworkError() async throws {
+        let url = URL(string: "https://example.com/click/cancelled")!
+        URLProtocolStub.register(.init(url: url, error: URLError(.cancelled)))
+        let handler = URLHandler(session: URLProtocolStub.session())
+        let components = try makeComponents(url.absoluteString)
+
+        await #expect(throws: CancellationError.self) {
+            try await handler.handleClick(urlComponents: components)
+        }
+    }
+
+    /// A genuine transport failure still maps to `.networkError`.
+    @Test func transportFailureMapsToNetworkError() async throws {
+        let url = URL(string: "https://example.com/click/offline")!
+        URLProtocolStub.register(.init(url: url, error: URLError(.notConnectedToInternet)))
+        let handler = URLHandler(session: URLProtocolStub.session())
+        let components = try makeComponents(url.absoluteString)
+
+        do {
+            _ = try await handler.handleClick(urlComponents: components)
+            Issue.record("expected handleClick to throw")
+        } catch let error as URLHandlerError {
+            guard case .networkError = error else {
+                Issue.record("expected .networkError, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/Tests/ShortIOSDKTests/URLHandlerTests.swift
+++ b/Tests/ShortIOSDKTests/URLHandlerTests.swift
@@ -16,8 +16,37 @@ struct URLHandlerTests {
         let handler = URLHandler(session: URLProtocolStub.session())
         let components = try makeComponents("https://example.com/click/missing")
 
-        await #expect(throws: URLHandlerError.self) {
-            try await handler.handleClick(urlComponents: components)
+        do {
+            _ = try await handler.handleClick(urlComponents: components)
+            Issue.record("expected handleClick to throw")
+        } catch let error as URLHandlerError {
+            guard case .linkNotValid = error else {
+                Issue.record("expected .linkNotValid, got \(error)")
+                return
+            }
+        }
+    }
+
+    /// `handleClick` appends `utm_medium`, and a server may hand the query back canonicalised.
+    /// A query-only difference is not a redirect, so a dead short link must stay `.linkNotValid`.
+    @Test func queryOnlyDifferenceIsNotTreatedAsARedirect() async throws {
+        let shortLink = URL(string: "https://example.com/click/missing")!
+        URLProtocolStub.register(.init(
+            statusCode: 404,
+            url: shortLink,
+            responseURL: URL(string: "https://example.com/click/missing?utm_medium=ios&extra=1")!
+        ))
+        let handler = URLHandler(session: URLProtocolStub.session())
+        let components = try makeComponents(shortLink.absoluteString)
+
+        do {
+            _ = try await handler.handleClick(urlComponents: components)
+            Issue.record("expected handleClick to throw")
+        } catch let error as URLHandlerError {
+            guard case .linkNotValid = error else {
+                Issue.record("expected .linkNotValid, got \(error)")
+                return
+            }
         }
     }
 

--- a/Tests/ShortIOSDKTests/URLProtocolStub.swift
+++ b/Tests/ShortIOSDKTests/URLProtocolStub.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// A `URLProtocol` returning canned responses, so tests never touch the network.
+///
+/// Stubs are keyed by host + path rather than a single global slot, so tests running in
+/// parallel don't overwrite each other. Requests are recorded for assertions.
+final class URLProtocolStub: URLProtocol, @unchecked Sendable {
+
+    struct Stub {
+        let statusCode: Int
+        let url: URL
+        /// The URL the response reports, when it differs from the one requested. `URLSession`
+        /// follows redirects transparently, so this is how a post-redirect response is modelled.
+        let responseURL: URL?
+        let body: Data?
+        let error: Error?
+
+        init(statusCode: Int = 200, url: URL, responseURL: URL? = nil, body: Data? = nil, error: Error? = nil) {
+            self.statusCode = statusCode
+            self.url = url
+            self.responseURL = responseURL
+            self.body = body
+            self.error = error
+        }
+    }
+
+    /// A snapshot of a request the protocol received, for assertions.
+    struct CapturedRequest: Sendable {
+        let url: URL?
+        let headers: [String: String]
+        let body: Data?
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var stubsByKey: [String: Stub] = [:]
+    nonisolated(unsafe) private static var capturedByKey: [String: CapturedRequest] = [:]
+
+    /// Registers a canned response, served for any request matching `stub.url`'s host + path.
+    static func register(_ stub: Stub) {
+        lock.lock(); defer { lock.unlock() }
+        stubsByKey[key(for: stub.url)] = stub
+    }
+
+    /// The most recent request seen for `url`'s host + path, or `nil` if none was served.
+    static func capturedRequest(for url: URL) -> CapturedRequest? {
+        lock.lock(); defer { lock.unlock() }
+        return capturedByKey[key(for: url)]
+    }
+
+    /// A session wired to this protocol. Pass to `ShortIOSDK.initialize(session:apiKey:domain:)`.
+    static func session() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        return URLSession(configuration: configuration)
+    }
+
+    // MARK: - Keying
+
+    /// Excludes the query, which the SDK appends to (`utm_medium`, `clid`, `c`).
+    private static func key(for url: URL) -> String { "\(url.host ?? "")\(url.path)" }
+
+    private static func key(for request: URLRequest) -> String {
+        request.url.map(key(for:)) ?? ""
+    }
+
+    private static func stub(for request: URLRequest) -> Stub? {
+        lock.lock(); defer { lock.unlock() }
+        return stubsByKey[key(for: request)]
+    }
+
+    private static func record(_ request: URLRequest) {
+        let captured = CapturedRequest(
+            url: request.url,
+            headers: request.allHTTPHeaderFields ?? [:],
+            body: drainBody(of: request)
+        )
+        lock.lock(); defer { lock.unlock() }
+        capturedByKey[key(for: request)] = captured
+    }
+
+    /// Reads the request body. `URLSession` streams `httpBody`, so it must be drained from
+    /// `httpBodyStream`; `httpBody` itself is `nil` by the time the protocol sees the request.
+    private static func drainBody(of request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        var data = Data()
+        stream.open()
+        defer { stream.close() }
+        let bufferSize = 1_024
+        while stream.hasBytesAvailable {
+            var buffer = [UInt8](repeating: 0, count: bufferSize)
+            let read = stream.read(&buffer, maxLength: bufferSize)
+            if read > 0 {
+                data.append(buffer, count: read)
+            } else {
+                break
+            }
+        }
+        return data.isEmpty ? nil : data
+    }
+
+    // MARK: - URLProtocol
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.record(self.request)
+
+        guard let stub = Self.stub(for: self.request) else {
+            // No canned response registered for this host + path. Fail loudly so a missing
+            // or colliding stub registration surfaces immediately instead of passing vacuously.
+            client?.urlProtocol(self, didFailWithError: StubError.noStubForRequest(self.request))
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        if let error = stub.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            client?.urlProtocolDidFinishLoading(self)
+            return
+        }
+
+        let response = HTTPURLResponse(
+            url: stub.responseURL ?? stub.url,
+            statusCode: stub.statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: stub.body ?? Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    private enum StubError: Error, CustomStringConvertible {
+        case noStubForRequest(URLRequest)
+
+        var description: String {
+            switch self {
+            case .noStubForRequest(let request):
+                return "URLProtocolStub has no registered stub for \(request.url?.host ?? "")\(request.url?.path ?? "")"
+            }
+        }
+    }
+}

--- a/Tests/ShortIOSDKTests/URLProtocolStub.swift
+++ b/Tests/ShortIOSDKTests/URLProtocolStub.swift
@@ -136,8 +136,12 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
 
     override func stopLoading() {}
 
-    private enum StubError: Error, CustomStringConvertible {
+    private enum StubError: LocalizedError, CustomStringConvertible {
         case noStubForRequest(URLRequest)
+
+        /// Without this, `localizedDescription` reports "(StubError error 0)" and a missing
+        /// stub surfaces as an unreadable failure.
+        var errorDescription: String? { description }
 
         var description: String {
             switch self {


### PR DESCRIPTION
Swift 6 support, and the networking calls now use async/await.

`handleOpen` and `trackConversion` are async. The old completion-handler and `clid`/`domain` overloads still work, but they're deprecated and will go away in 2.0.0.

Platform floor is now iOS 15 / macOS 12 — that's what `URLSession.data(for:)` needs. It wasn't declared before.

One behaviour fix while I was in there: a short link whose destination returns an error was coming back as `linkNotValid`, which sends you looking at the wrong thing. The link is fine, the page it points at isn't. That case is now `destinationUnavailable`.

Also added a test target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async/await APIs for opening short links and tracking conversions.
  * Automatically captures and reuses click identifiers during conversion tracking.
  * Added clearer errors for uninitialized use, unavailable destinations, cancellations, and network failures.
  * Added Swift 6 concurrency support and iOS 15/macOS 12 platform support.

* **Documentation**
  * Updated usage examples, migration guidance, universal-link handling, and API deprecation notes.

* **Tests**
  * Expanded coverage for link creation, secure links, redirects, errors, conversions, initialization, and concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
