### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,15 +113,18 @@ jobs:
         run: |
           set -o pipefail
 
-          # Sort numerically on (major, minor). Sorting the identifier as a
-          # string ranks iOS-26-10 below iOS-26-2.
+          # Sort numerically on version components in both branches. A string
+          # sort ranks 26.10 below 26.2, and simctl does not promise an order,
+          # so an unsorted `last` over an explicit-version match would pick an
+          # arbitrary patch when both 16.4 and 16.4.1 are installed.
           RUNTIME=$(xcrun simctl list runtimes -j | jq -r --arg v "$IOS_VERSION" '
             .runtimes
             | map(select(.platform == "iOS" and .isAvailable))
-            | if $v == "latest"
-              then sort_by(.version | split(".") | map(tonumber)) | last
-              else map(select(.version | startswith($v))) | last
+            | if $v == "latest" then .
+              else map(select(.version | startswith($v)))
               end
+            | sort_by(.version | split(".") | map(tonumber))
+            | last
             | .identifier // empty
           ')
           if [ -z "$RUNTIME" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,173 @@
+name: CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+
+# Least privilege: nothing here needs more than reading the checkout.
+permissions:
+  contents: read
+
+# A force-push to a PR supersedes the run already in flight; don't pay for both.
+# Pushes to main are exempt — cancelling those leaves a merged commit with no
+# completed run, and the README badge reporting a cancellation.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  spm-test:
+    name: swift test (macOS)
+    runs-on: macos-15
+    # A wedged toolchain otherwise runs to the 360-minute default, billed at the
+    # 10x macOS multiplier.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          # Pinned so a newly released Xcode cannot turn CI red on an unchanged
+          # tree. macos-15 currently ships 16.0-16.4 and 26.0-26.3; this and the
+          # runs-on image above are a matched pair, so bump them together.
+          xcode-version: "26.3"
+
+      - name: Show toolchain
+        run: |
+          swift --version
+          xcodebuild -version
+
+      - name: Build
+        run: swift build -v
+
+      - name: Test
+        run: swift test -v
+
+  # Compile-time enforcement of the floor declared in Package.swift. Swift's
+  # availability checking is a compile-time feature, so building at the minimum
+  # deployment target is what actually catches "used an iOS 16 API without an
+  # #available guard" — a booted simulator is not required and cannot be had:
+  # Apple no longer publishes an iOS 15 simulator runtime for current Xcode
+  # ("iOS 15.5 is not available for download"). If this job is ever the only
+  # thing standing between the SDK and an iOS 15 user, that is by necessity.
+  deployment-floor-build:
+    name: build @ deployment floor (iOS 15.0)
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          # Pinned so a newly released Xcode cannot turn CI red on an unchanged
+          # tree. macos-15 currently ships 16.0-16.4 and 26.0-26.3; this and the
+          # runs-on image above are a matched pair, so bump them together.
+          xcode-version: "26.3"
+
+      # generic/ destination compiles without booting anything.
+      - name: Build for iOS 15.0
+        run: |
+          xcodebuild build \
+            -scheme ShortIOSDK \
+            -destination 'generic/platform=iOS Simulator' \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0
+
+  ios-simulator-test:
+    name: xcodebuild test (iOS ${{ matrix.ios }})
+    runs-on: macos-15
+    timeout-minutes: 45
+    strategy:
+      # Knowing whether every runtime broke or only the oldest is the useful
+      # signal; don't let the first failure hide the rest.
+      fail-fast: false
+      matrix:
+        # "16.4" is the oldest runtime Apple still publishes for current Xcode,
+        # so it is the real, testable floor. Downloading it costs several GB and
+        # a few minutes per run — drop this leg if that outweighs the coverage.
+        ios: ["16.4", "latest"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
+        with:
+          # Pinned so a newly released Xcode cannot turn CI red on an unchanged
+          # tree. macos-15 currently ships 16.0-16.4 and 26.0-26.3; this and the
+          # runs-on image above are a matched pair, so bump them together.
+          xcode-version: "26.3"
+
+      - name: Install iOS ${{ matrix.ios }} runtime
+        if: matrix.ios != 'latest'
+        env:
+          IOS_VERSION: ${{ matrix.ios }}
+        run: xcodebuild -downloadPlatform iOS -buildVersion "$IOS_VERSION"
+
+      # Device names and runtime sets change between runner images, so a
+      # hardcoded `name=iPhone 17` eventually fails on device lookup rather than
+      # on the code. Resolve a concrete UDID instead, and fail loudly with a
+      # device dump if the runtime this leg asked for is not present.
+      - name: Select iOS simulator
+        env:
+          IOS_VERSION: ${{ matrix.ios }}
+        run: |
+          set -o pipefail
+
+          # Sort numerically on (major, minor). Sorting the identifier as a
+          # string ranks iOS-26-10 below iOS-26-2.
+          RUNTIME=$(xcrun simctl list runtimes -j | jq -r --arg v "$IOS_VERSION" '
+            .runtimes
+            | map(select(.platform == "iOS" and .isAvailable))
+            | if $v == "latest"
+              then sort_by(.version | split(".") | map(tonumber)) | last
+              else map(select(.version | startswith($v))) | last
+              end
+            | .identifier // empty
+          ')
+          if [ -z "$RUNTIME" ]; then
+            echo "::error::No available iOS $IOS_VERSION runtime on this runner image."
+            xcrun simctl list runtimes
+            exit 1
+          fi
+
+          UDID=$(xcrun simctl list devices available -j | jq -r --arg r "$RUNTIME" '
+            .devices[$r] // []
+            | map(select(.name | startswith("iPhone")))
+            | last
+            | .udid // empty
+          ')
+
+          # A freshly downloaded runtime may arrive with no prebuilt devices.
+          # iPhone SE (3rd generation) exists in every runtime from 15.4 up, so
+          # it is the safe device type to create across this matrix.
+          if [ -z "$UDID" ]; then
+            echo "No prebuilt iPhone for $RUNTIME; creating one."
+            UDID=$(xcrun simctl create ci-iphone \
+              com.apple.CoreSimulator.SimDeviceType.iPhone-SE-3rd-generation \
+              "$RUNTIME")
+          fi
+          if [ -z "$UDID" ]; then
+            echo "::error::Could not obtain an iPhone simulator for $RUNTIME."
+            xcrun simctl list devices available
+            exit 1
+          fi
+
+          echo "Using $RUNTIME simulator $UDID"
+          echo "DESTINATION=platform=iOS Simulator,id=$UDID" >> "$GITHUB_ENV"
+
+      - name: Test
+        run: |
+          xcodebuild test \
+            -scheme ShortIOSDK \
+            -destination "$DESTINATION" \
+            -resultBundlePath TestResults.xcresult
+
+      # Only on failure: the .xcresult opens in Xcode and shows the failing
+      # assertion directly, instead of leaving only scrollback to read.
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ios-simulator-test-results-${{ matrix.ios }}
+          path: TestResults.xcresult
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # ShortLink SDK for iOS (Deep Linking Integration using Short.io)
 
+[![CI](https://github.com/Short-io/ios-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/Short-io/ios-sdk/actions/workflows/ci.yml)
+
 This SDK allows you to create short links using the [Short.io](https://short.io/) API based on a public API key and custom parameters. It also supports iOS deep linking integration using Universal Links.
 
 ## ✨ Features


### PR DESCRIPTION
Adds GitHub Actions CI for the SDK. No source changes — the workflow and a status badge only.

## Jobs

| Job | What it covers |
|---|---|
| `spm-test` | `swift build` + `swift test` on macOS |
| `deployment-floor-build` | Builds at `IPHONEOS_DEPLOYMENT_TARGET=15.0` |
| `ios-simulator-test` | `xcodebuild test` across a matrix of iOS simulator runtimes |

## Notes on a few decisions

**The deployment floor is checked by compiling, not by running.** `Package.swift` declares `.iOS(.v15)`, but Apple no longer publishes an iOS 15 simulator runtime for current Xcode — `xcodebuild -downloadPlatform iOS -buildVersion 15.5` returns "iOS 15.5 is not available for download". Since Swift availability checking is a compile-time feature, building at the declared target is what actually catches an unguarded newer API. `16.4` is the oldest runtime still published, so that is the real runtime floor and forms one leg of the test matrix.

**The simulator is resolved, not hardcoded.** A pinned `name=iPhone 17` fails on device lookup whenever the runner image changes its device set, which surfaces as a confusing failure unrelated to the code. The workflow queries `simctl` for a UDID instead, sorts runtime versions numerically (a string sort ranks `iOS-26-10` below `iOS-26-2`), creates a device when a freshly downloaded runtime ships without one, and fails loudly with a device dump if nothing suitable exists.

**Pinning.** Runner image, Xcode version, and every action are pinned — actions to commit SHAs at their current majors, which also keeps them off the deprecated Node 20 runtime. The runner image and Xcode version are a matched pair and should be bumped together.

**Cost controls.** `GITHUB_TOKEN` is restricted to `contents: read`. Every job has a timeout, so a wedged simulator cannot run to the 360-minute default at the 10x macOS billing rate. Concurrency cancels superseded PR runs but exempts `main`, so merged commits keep a completed run.

## Verified locally

- `swift test` — 21 tests, 9 suites, passing
- `xcodebuild test` on an iOS 26.2 simulator — 21 passed per the result bundle
- Build at the iOS 15.0 floor — `BUILD SUCCEEDED`, target `ios15.0-simulator`
- Runtime selector exercised for both the `latest` and explicit-version paths

## Not yet verified

The `16.4` matrix leg needs a multi-GB runtime download and could not be exercised locally; this PR is its first real run. If it proves too slow or flaky, removing `"16.4"` from the `ios:` array degrades cleanly to a single-runtime job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated build and test checks for macOS and iOS across supported simulator versions.
  * Added failure-only test result artifacts for easier troubleshooting.
  * Added pull request and main-branch status visibility through a README workflow badge.
* **Chores**
  * Configured manual, pull request, and main-branch workflow triggers with cancellation of superseded runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->